### PR TITLE
Refined mobile navigation + Jupyter website top level

### DIFF
--- a/jupyter_alabaster_theme/jupyter/layout.html
+++ b/jupyter_alabaster_theme/jupyter/layout.html
@@ -38,7 +38,7 @@
 {%- set bs_content_width = render_sidebar and "9" or "12"%}
 {%- macro bsidebar() %}
       {%- if render_sidebar %}
-      <div class="{{ bs_span_prefix }}3">
+      <div class="col-sm-4 {{ bs_span_prefix }}3">
         <div id="sidebar" class="bs-sidenav" role="complementary">
           {%- for sidebartemplate in sidebars %}
             {%- include sidebartemplate %}

--- a/jupyter_alabaster_theme/jupyter/mobile_sidebar.html
+++ b/jupyter_alabaster_theme/jupyter/mobile_sidebar.html
@@ -8,8 +8,11 @@
 <div>
   {% set list = theTocTree.split("Header: ") %}
   <div class="mobile-nav-current-dropdown" data-toggle = "collapse" data-target = "#sectionList">
+    <div class="mobile-nav-current">
       <h3 class="mobile-nav-current-section">User Documentation</h3>
       <h2 class="mobile-nav-current-page">Installation</h2>
+    </div>
+    <img class="mobile-nav-expand-icon" src="{{ pathto("_static/_images/jupytertheme-images/expand.svg", 1) }}" alt="expand icon"/>
   </div>
   <div  id="sectionList" class = "collapse">
   {% for section in list[1:] %}

--- a/jupyter_alabaster_theme/jupyter/mobile_sidebar.html
+++ b/jupyter_alabaster_theme/jupyter/mobile_sidebar.html
@@ -12,7 +12,9 @@
       <h3 class="mobile-nav-current-section">User Documentation</h3>
       <h2 class="mobile-nav-current-page">Installation</h2>
     </div>
-    <img class="mobile-nav-expand-icon" src="{{ pathto("_static/_images/jupytertheme-images/expand.svg", 1) }}" alt="expand icon"/>
+    <div class="top-mobile-nav-expand">
+      <img class="mobile-nav-expand-icon" src="{{ pathto("_static/_images/jupytertheme-images/expand.svg", 1) }}" alt="expand icon"/>
+    </div>
   </div>
   <div  id="sectionList" class = "collapse">
   {% for section in list[1:] %}

--- a/jupyter_alabaster_theme/jupyter/static/css/jupytertheme.css
+++ b/jupyter_alabaster_theme/jupyter/static/css/jupytertheme.css
@@ -313,6 +313,11 @@ p.caption {
 }
 /* Mobile Navbar Styling */
 
+.mobile-nav-current {
+  max-width: 90%;
+  display: inline-block;
+}
+
 .mobile-nav-current-dropdown {
     padding: 16px 20px;
     border: 2px solid #BDBDBD;
@@ -338,6 +343,13 @@ p.caption {
   width: 100%;
 }
 
+.mobile-nav-section:active {
+  -webkit-box-shadow: none;
+  -moz-box-shadow: none;
+  -o-box-shadow: none;
+  box-shadow: none;
+}
+
 .mobile-nav-header {
     font-size: 20px;
     margin: 12px 0px;
@@ -354,10 +366,19 @@ p.caption {
 }
 
 .mobile-nav-expand-icon {
-    -webkit-transition: .4s ease-in-out;
-    -moz-transition: .4s ease-in-out;
-    -o-transition: .4s ease-in-out;
-    transition: .4s ease-in-out;
+    -webkit-transition: .2s ease-in-out;
+    -moz-transition: .2s ease-in-out;
+    -o-transition: .2s ease-in-out;
+    transition: .2s ease-in-out;
+    float: right;
+}
+
+.close-icon {
+  /* Add this class to a mobile nav item expand icon to rotate */
+  -webkit-transform: rotate(45deg);
+  -mox-transform: rotate(45deg);
+  -o-transform: rotate(45deg);
+  transform: rotate(45deg);
 }
 
 .toctree-l1 > a.reference {

--- a/jupyter_alabaster_theme/jupyter/static/css/jupytertheme.css
+++ b/jupyter_alabaster_theme/jupyter/static/css/jupytertheme.css
@@ -360,6 +360,12 @@ p.caption {
   padding-left: 16px;
 }
 
+.top-mobile-nav-expand {
+  float: right;
+  /* Half of the height of the top navigation box */
+  padding-top: 17.5px;
+}
+
 .mobile-nav-expand {
   float: right;
   padding-top: 12px;
@@ -428,6 +434,13 @@ div.admonition p.admonition-title {
 }
 div.admonition dl dd {
   margin: 0px 0px 4px 28px;
+}
+a.headerlink {
+  color: white;
+}
+a.headerlink:hover {
+  color: #424242;
+  background-color: white;
 }
 .docs-breadcrumbs {
     height: 36px;

--- a/jupyter_alabaster_theme/jupyter/static/css/logo-nav.css
+++ b/jupyter_alabaster_theme/jupyter/static/css/logo-nav.css
@@ -688,7 +688,9 @@ body {
     }
     .nav>li>a {
         font-size: 13px;
-        letter-spacing: 1px;
+        letter-spacing: .4px;
+        padding-left: 8px;
+        padding-right: 8px;
     }
 }
 /* Small devices (tablets, 768px and up) */
@@ -754,6 +756,11 @@ body {
     }
     .desktop-test {
       display: none;
+    }
+    .nav>li>a {
+        letter-spacing: 1px;
+        padding-left: 16px;
+        padding-right: 16px;
     }
 }
 /* Extra small devices (these are mostly fixes to make sure elements act correctly to look good) */

--- a/jupyter_alabaster_theme/jupyter/static/js/mobile-nav.js
+++ b/jupyter_alabaster_theme/jupyter/static/js/mobile-nav.js
@@ -1,6 +1,11 @@
 $(document).on('ready', function() {
-    $('.mobile-nav-section').on('click', function() {
-        console.log('pressed');
-        $('.mobile-nav-expand-icon').css('transform', 'rotate(45deg)');
+    $('.mobile-nav-section, .mobile-nav-current-dropdown').on('click', function() {
+        var openToggle = $(this).find('.mobile-nav-expand-icon');
+        if (openToggle.hasClass('close-icon')) {
+          openToggle.removeClass('close-icon');
+        }
+        else {
+          openToggle.addClass('close-icon');
+        }
     });
 });


### PR DESCRIPTION
-Polished design of the top level mobile navigation on pages
-All of the CSS animations are now working as intended
-Changed the jupyter website top level design to match the website's styling update

### Mobile navigation bar
![1lj6sg](https://cloud.githubusercontent.com/assets/6437976/24010143/3c52eee2-0a34-11e7-94f0-edb7cc0b4a71.gif)

### Website navigation bar before
![screen shot 2017-03-16 at 10 36 53 am](https://cloud.githubusercontent.com/assets/6437976/24010267/a2977ff6-0a34-11e7-9718-3b3f7ccea513.png)

### Website navigation bar after
![screen shot 2017-03-16 at 10 35 37 am](https://cloud.githubusercontent.com/assets/6437976/24010288/aafcb2ce-0a34-11e7-8d63-85879516685f.png)



